### PR TITLE
Allow forcing lower case runner names

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -118,6 +118,9 @@ type Incus struct {
 
 	// InstanceType allows you to choose between a virtual machine and a container
 	InstanceType IncusImageType `toml:"instance_type" json:"instance-type"`
+
+	// UseLowerCaseHostnames makes the runner name all lowercase before sending it to incus.
+	UseLowerCaseHostnames bool `toml:"use_lowercase_hostnames" json:"use_lowercase_hostnames"`
 }
 
 func (l *Incus) GetInstanceType() IncusImageType {

--- a/provider/incus_test.go
+++ b/provider/incus_test.go
@@ -17,6 +17,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	commonParams "github.com/cloudbase/garm-provider-common/params"
@@ -184,11 +185,12 @@ func TestGetCreateInstanceArgsContainer(t *testing.T) {
 					Profiles:     []string{"default", "container"},
 					Description:  "Github runner provisioned by garm",
 					Config: map[string]string{
-						"user.user-data":    `#cloud-config`,
-						osTypeKeyName:       "linux",
-						osArchKeyNAme:       "amd64",
-						controllerIDKeyName: "controller",
-						poolIDKey:           "default",
+						"user.user-data":      `#cloud-config`,
+						osTypeKeyName:         "linux",
+						osArchKeyNAme:         "amd64",
+						controllerIDKeyName:   "controller",
+						poolIDKey:             "default",
+						runnerInstanceKeyName: "test-instance",
 					},
 				},
 				Source: api.InstanceSource{
@@ -259,7 +261,6 @@ func TestGetCreateInstanceArgsVM(t *testing.T) {
 	cli.On("GetImageAliasArchitectures", config.IncusImageType("virtual-machine").String(), "windows").Return(aliases, nil)
 	cli.On("GetImage", aliases["x86_64"].Target).Return(&api.Image{Fingerprint: "123abc"}, "", nil)
 	cli.On("GetProfileNames").Return([]string{"default", "virtual-machine"}, nil)
-	specs := extraSpecs{}
 	tests := []struct {
 		name            string
 		bootstrapParams commonParams.BootstrapInstance
@@ -275,7 +276,7 @@ func TestGetCreateInstanceArgsVM(t *testing.T) {
 		{
 			name: "success vm instance",
 			bootstrapParams: commonParams.BootstrapInstance{
-				Name:    "test-instance",
+				Name:    "test-InStAnCe",
 				Tools:   tools,
 				Image:   "windows",
 				Flavor:  "virtual-machine",
@@ -283,6 +284,43 @@ func TestGetCreateInstanceArgsVM(t *testing.T) {
 				PoolID:  "default",
 				OSArch:  commonParams.Amd64,
 				OSType:  commonParams.Windows,
+			},
+			expected: api.InstancesPost{
+				Name: "test-InStAnCe",
+				InstancePut: api.InstancePut{
+					Architecture: "x86_64",
+					Profiles:     []string{"default", "virtual-machine"},
+					Description:  "Github runner provisioned by garm",
+					Config: map[string]string{
+						"user.user-data":      "#ps1_sysnative\n" + "#cloud-config",
+						osTypeKeyName:         "windows",
+						osArchKeyNAme:         "amd64",
+						controllerIDKeyName:   "controller",
+						poolIDKey:             "default",
+						runnerInstanceKeyName: "test-InStAnCe",
+						"security.secureboot": "false",
+					},
+				},
+				Source: api.InstanceSource{
+					Type:        "image",
+					Fingerprint: "123abc",
+				},
+				Type: "virtual-machine",
+			},
+			errString: "",
+		},
+		{
+			name: "success vm instance with lower case name",
+			bootstrapParams: commonParams.BootstrapInstance{
+				Name:       "test-InStAnCe",
+				Tools:      tools,
+				Image:      "windows",
+				Flavor:     "virtual-machine",
+				RepoURL:    "mock-repo-url",
+				PoolID:     "default",
+				OSArch:     commonParams.Amd64,
+				OSType:     commonParams.Windows,
+				ExtraSpecs: json.RawMessage(`{"use_lowercase_hostnames": true}`),
 			},
 			expected: api.InstancesPost{
 				Name: "test-instance",
@@ -296,6 +334,7 @@ func TestGetCreateInstanceArgsVM(t *testing.T) {
 						osArchKeyNAme:         "amd64",
 						controllerIDKeyName:   "controller",
 						poolIDKey:             "default",
+						runnerInstanceKeyName: "test-InStAnCe",
 						"security.secureboot": "false",
 					},
 				},
@@ -311,6 +350,9 @@ func TestGetCreateInstanceArgsVM(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			specs, err := parseExtraSpecsFromBootstrapParams(tt.bootstrapParams)
+			require.NoError(t, err)
+
 			ret, err := l.getCreateInstanceArgs(ctx, tt.bootstrapParams, specs)
 			if tt.errString != "" {
 				require.Error(t, err)

--- a/provider/specs.go
+++ b/provider/specs.go
@@ -26,9 +26,10 @@ import (
 )
 
 type extraSpecs struct {
-	ExtraPackages   []string `json:"extra_packages,omitempty" jsonschema:"description=A list of packages that cloud-init should install on the instance."`
-	DisableUpdates  bool     `json:"disable_updates,omitempty" jsonschema:"description=Whether to disable updates when cloud-init comes online."`
-	EnableBootDebug bool     `json:"enable_boot_debug,omitempty" jsonschema:"description=Allows providers to set the -x flag in the runner install script."`
+	ExtraPackages         []string `json:"extra_packages,omitempty" jsonschema:"description=A list of packages that cloud-init should install on the instance."`
+	DisableUpdates        bool     `json:"disable_updates,omitempty" jsonschema:"description=Whether to disable updates when cloud-init comes online."`
+	EnableBootDebug       bool     `json:"enable_boot_debug,omitempty" jsonschema:"description=Allows providers to set the -x flag in the runner install script."`
+	UseLowerCaseHostnames bool     `json:"use_lowercase_hostnames,omitempty" jsonschema:"description=Instructs the provider to make the hostname of the runner all lowercase."`
 	cloudconfig.CloudConfigSpec
 }
 

--- a/provider/specs_test.go
+++ b/provider/specs_test.go
@@ -33,11 +33,12 @@ var testCases = []struct {
 }{
 	{
 		name:  "full specs",
-		input: json.RawMessage(`{"disable_updates": true, "extra_packages": ["package1", "package2"], "enable_boot_debug": true, "runner_install_template": "IyEvYmluL2Jhc2gKZWNobyBJbnN0YWxsaW5nIHJ1bm5lci4uLg==", "pre_install_scripts": {"setup.sh": "IyEvYmluL2Jhc2gKZWNobyBTZXR1cCBzY3JpcHQuLi4="}, "extra_context": {"key": "value"}}`),
+		input: json.RawMessage(`{"use_lowercase_hostnames": false, "disable_updates": true, "extra_packages": ["package1", "package2"], "enable_boot_debug": true, "runner_install_template": "IyEvYmluL2Jhc2gKZWNobyBJbnN0YWxsaW5nIHJ1bm5lci4uLg==", "pre_install_scripts": {"setup.sh": "IyEvYmluL2Jhc2gKZWNobyBTZXR1cCBzY3JpcHQuLi4="}, "extra_context": {"key": "value"}}`),
 		expectedOutput: extraSpecs{
-			DisableUpdates:  true,
-			ExtraPackages:   []string{"package1", "package2"},
-			EnableBootDebug: true,
+			DisableUpdates:        true,
+			ExtraPackages:         []string{"package1", "package2"},
+			EnableBootDebug:       true,
+			UseLowerCaseHostnames: false,
 			CloudConfigSpec: cloudconfig.CloudConfigSpec{
 				RunnerInstallTemplate: []byte("#!/bin/bash\necho Installing runner..."),
 				PreInstallScripts: map[string][]byte{

--- a/provider/util.go
+++ b/provider/util.go
@@ -66,12 +66,15 @@ func incusInstanceToAPIInstance(instance *api.InstanceFull) commonParams.Provide
 	incusOS := instance.ExpandedConfig["image.os"]
 
 	osType, _ := util.OSToOSType(incusOS)
-
 	if osType == "" {
 		osTypeFromTag := instance.ExpandedConfig[osTypeKeyName]
 		osType = commonParams.OSType(osTypeFromTag)
 	}
 	osRelease := instance.ExpandedConfig["image.release"]
+	runnerName := instance.Name
+	if instance.ExpandedConfig[runnerInstanceKeyName] != "" {
+		runnerName = instance.ExpandedConfig[runnerInstanceKeyName]
+	}
 
 	state := instance.State
 	addresses := []commonParams.Address{}
@@ -93,7 +96,7 @@ func incusInstanceToAPIInstance(instance *api.InstanceFull) commonParams.Provide
 	return commonParams.ProviderInstance{
 		OSArch:     instanceArch,
 		ProviderID: instance.Name,
-		Name:       instance.Name,
+		Name:       runnerName,
 		OSType:     osType,
 		OSName:     strings.ToLower(incusOS),
 		OSVersion:  osRelease,


### PR DESCRIPTION
Some workloads enforce RFC 1123, which requires hostnames to be all lower case. One such example is k8s. This PR adds the ability to force the incus provider to use lower case for instance names, while maintaining the runner ID we see in GARM.