### PR TITLE
feat: add external lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,7 @@ configured in the provider config file, one optional block per hook:
 
 ```toml
 [hooks.vm_pre_create]
-    command = "/opt/garm/hooks/vm-pre-create.sh"
-    args = ["--role", "builder"]
+    command = "/opt/garm/hooks/vm-pre-create.sh --role builder"
     timeout = 60
     ignore_failure = false
 
@@ -174,10 +173,10 @@ The six hooks fire at:
 | `vm_pre_delete` | before the instance is stopped/removed |
 | `vm_post_delete` | after the instance is removed |
 
-Per-hook options: `command` (path to an executable — a shell script needs a
-shebang and the `+x` bit; it is run directly, **not** via a shell), `args`
-(passed verbatim), `timeout` (seconds; default and maximum `60`),
-`ignore_failure` (default `false`).
+Per-hook options: `command` (a shell command line run via `/bin/sh -c`),
+`timeout` (seconds; default and maximum `60`), `ignore_failure` (default
+`false`; only affects create/start hooks — delete-hook failures never block
+deletion).
 
 Every hook receives context via environment: `GARM_HOOK`, `GARM_HOOK_PHASE`,
 `GARM_INSTANCE_NAME`, `GARM_POOL_ID`, `GARM_CONTROLLER_ID`, `GARM_OS_TYPE`,
@@ -185,11 +184,9 @@ Every hook receives context via environment: `GARM_HOOK`, `GARM_HOOK_PHASE`,
 
 `vm_pre_create` receives the incus `InstancesPost` JSON on **stdin** and must
 echo the (possibly modified) `InstancesPost` JSON on **stdout**; the provider
-applies it. It MUST NOT change instance-identity fields (`name` and the
-`user.runner-controller-id` / `user.runner-pool-id` / `user.os-type` /
-`user.os-arch` config keys) — those are used by garm and by later hooks. All
-other hooks receive an instance-context JSON on stdin and their stdout is
-ignored.
+applies it. It must not change the instance `name` (garm tracks the instance by
+it). All other hooks receive an instance-context JSON on stdin and their stdout
+is ignored.
 
 Failure handling: if a create/start hook fails and `ignore_failure` is false,
 the instance is destroyed and the create returns an error; with `ignore_failure`
@@ -200,5 +197,6 @@ instance (garm retries failed creates), so they MUST be idempotent.
 
 Security: `vm_pre_create` stdin includes the full `InstancesPost`, which contains
 `user.user-data` (the runner registration token and other bootstrap secrets);
-and every hook inherits the provider process environment. Only configure trusted
-hook executables. See [`examples/hooks`](examples/hooks) for sample scripts.
+and every hook inherits the provider process environment (including `PATH`).
+Only configure trusted hook commands. See [`examples/hooks`](examples/hooks) for
+sample scripts.

--- a/README.md
+++ b/README.md
@@ -138,3 +138,67 @@ You can also set a spec when creating a new pool, using the same flag.
 Workers in that pool will be created taking into account the specs you set on the pool.
 
 Aside from the above schema, this provider also supports the generic schema implemented by [`garm-provider-common`](https://github.com/cloudbase/garm-provider-common/tree/main#userdata)
+
+## Lifecycle hooks
+
+The provider can run external commands at instance lifecycle points. Hooks are
+configured in the provider config file, one optional block per hook:
+
+```toml
+[hooks.vm_pre_create]
+    command = "/opt/garm/hooks/vm-pre-create.sh"
+    args = ["--role", "builder"]
+    timeout = 60
+    ignore_failure = false
+
+[hooks.vm_post_create]
+    command = "/opt/garm/hooks/vm-post-create.sh"
+[hooks.vm_pre_start]
+    command = "/opt/garm/hooks/vm-pre-start.sh"
+[hooks.vm_post_start]
+    command = "/opt/garm/hooks/vm-post-start.sh"
+[hooks.vm_pre_delete]
+    command = "/opt/garm/hooks/vm-pre-delete.sh"
+[hooks.vm_post_delete]
+    command = "/opt/garm/hooks/vm-post-delete.sh"
+```
+
+The six hooks fire at:
+
+| Hook | When |
+| --- | --- |
+| `vm_pre_create` | before the instance is created |
+| `vm_post_create` | after create, before start (instance stopped) |
+| `vm_pre_start` | before start |
+| `vm_post_start` | after the instance has an IPv4 (incus-agent reachable) |
+| `vm_pre_delete` | before the instance is stopped/removed |
+| `vm_post_delete` | after the instance is removed |
+
+Per-hook options: `command` (path to an executable — a shell script needs a
+shebang and the `+x` bit; it is run directly, **not** via a shell), `args`
+(passed verbatim), `timeout` (seconds; default and maximum `60`),
+`ignore_failure` (default `false`).
+
+Every hook receives context via environment: `GARM_HOOK`, `GARM_HOOK_PHASE`,
+`GARM_INSTANCE_NAME`, `GARM_POOL_ID`, `GARM_CONTROLLER_ID`, `GARM_OS_TYPE`,
+`GARM_OS_ARCH`, `GARM_INSTANCE_TYPE`, `GARM_HOOK_IGNORE_FAILURE`.
+
+`vm_pre_create` receives the incus `InstancesPost` JSON on **stdin** and must
+echo the (possibly modified) `InstancesPost` JSON on **stdout**; the provider
+applies it. It MUST NOT change instance-identity fields (`name` and the
+`user.runner-controller-id` / `user.runner-pool-id` / `user.os-type` /
+`user.os-arch` config keys) — those are used by garm and by later hooks. All
+other hooks receive an instance-context JSON on stdin and their stdout is
+ignored.
+
+Failure handling: if a create/start hook fails and `ignore_failure` is false,
+the instance is destroyed and the create returns an error; with `ignore_failure`
+true the failure is logged and creation continues. Delete-hook failures never
+block deletion (they are logged). Delete hooks also fire during
+`RemoveAllInstances` (once per instance) and may fire for an already-gone
+instance (garm retries failed creates), so they MUST be idempotent.
+
+Security: `vm_pre_create` stdin includes the full `InstancesPost`, which contains
+`user.user-data` (the runner registration token and other bootstrap secrets);
+and every hook inherits the provider process environment. Only configure trusted
+hook executables. See [`examples/hooks`](examples/hooks) for sample scripts.

--- a/README.md
+++ b/README.md
@@ -188,12 +188,41 @@ applies it. It must not change the instance `name` (garm tracks the instance by
 it). All other hooks receive an instance-context JSON on stdin and their stdout
 is ignored.
 
+Hooks can also be set per pool through `extra_specs`, which **replaces** the
+provider config hooks for that pool:
+
+- no `hooks` key → the provider config hooks apply;
+- `hooks` set → only those hooks run (config hooks are ignored, so re-declare
+  any you still want);
+- `hooks: {}` → no hooks for that pool.
+
+The `hooks` object takes the same per-hook fields as the config file:
+
+```json
+{
+    "hooks": {
+        "vm_pre_create": {
+            "command": "/opt/garm/hooks/vm-pre-create.sh --role builder",
+            "timeout": 60
+        },
+        "vm_pre_delete": {
+            "command": "/opt/garm/hooks/vm-pre-delete.sh",
+            "ignore_failure": true
+        }
+    }
+}
+```
+
+```bash
+garm-cli pool update <POOL_ID> --extra-specs='{"hooks":{"vm_pre_create":{"command":"/opt/garm/hooks/vm-pre-create.sh"}}}'
+```
+
 Failure handling: if a create/start hook fails and `ignore_failure` is false,
 the instance is destroyed and the create returns an error; with `ignore_failure`
 true the failure is logged and creation continues. Delete-hook failures never
 block deletion (they are logged). Delete hooks also fire during
-`RemoveAllInstances` (once per instance) and may fire for an already-gone
-instance (garm retries failed creates), so they MUST be idempotent.
+`RemoveAllInstances` (once per instance) and may run more than once if a
+deletion is retried, so they MUST be idempotent.
 
 Security: `vm_pre_create` stdin includes the full `InstancesPost`, which contains
 `user.user-data` (the runner registration token and other bootstrap secrets);

--- a/config/config.go
+++ b/config/config.go
@@ -85,13 +85,11 @@ func NewConfig(cfgFile string) (*Incus, error) {
 const DefaultHookTimeout = 60
 
 // Hook defines an external command executed at an instance lifecycle point.
-// Command is executed directly (not via a shell); it must be an executable file
-// (e.g. a shell script with a shebang, marked +x).
+// Command is a shell command line run via "/bin/sh -c".
 type Hook struct {
-	Command       string   `toml:"command" json:"command"`
-	Args          []string `toml:"args" json:"args"`
-	Timeout       int      `toml:"timeout" json:"timeout"`
-	IgnoreFailure bool     `toml:"ignore_failure" json:"ignore_failure"`
+	Command       string `toml:"command" json:"command"`
+	Timeout       int    `toml:"timeout" json:"timeout"`
+	IgnoreFailure bool   `toml:"ignore_failure" json:"ignore_failure"`
 }
 
 // Hooks groups the supported instance lifecycle hooks.
@@ -104,21 +102,14 @@ type Hooks struct {
 	VMPostDelete *Hook `toml:"vm_post_delete" json:"vm_post_delete"`
 }
 
-// Validate checks the hook command is a usable executable and normalizes the
-// timeout to the (0, DefaultHookTimeout] range.
+// Validate checks the hook has a command and normalizes the timeout to the
+// (0, DefaultHookTimeout] range.
 func (h *Hook) Validate() error {
 	if h == nil {
 		return nil
 	}
 	if h.Command == "" {
 		return fmt.Errorf("hook command is empty")
-	}
-	info, err := os.Stat(h.Command)
-	if err != nil {
-		return fmt.Errorf("hook command %q: %w", h.Command, err)
-	}
-	if info.IsDir() || info.Mode()&0o111 == 0 {
-		return fmt.Errorf("hook command %q is not an executable file", h.Command)
 	}
 	if h.Timeout <= 0 || h.Timeout > DefaultHookTimeout {
 		h.Timeout = DefaultHookTimeout

--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,65 @@ func NewConfig(cfgFile string) (*Incus, error) {
 	return &config, nil
 }
 
+// DefaultHookTimeout is the default and maximum per-hook execution time, in
+// seconds.
+const DefaultHookTimeout = 60
+
+// Hook defines an external command executed at an instance lifecycle point.
+// Command is executed directly (not via a shell); it must be an executable file
+// (e.g. a shell script with a shebang, marked +x).
+type Hook struct {
+	Command       string   `toml:"command" json:"command"`
+	Args          []string `toml:"args" json:"args"`
+	Timeout       int      `toml:"timeout" json:"timeout"`
+	IgnoreFailure bool     `toml:"ignore_failure" json:"ignore_failure"`
+}
+
+// Hooks groups the supported instance lifecycle hooks.
+type Hooks struct {
+	VMPreCreate  *Hook `toml:"vm_pre_create" json:"vm_pre_create"`
+	VMPostCreate *Hook `toml:"vm_post_create" json:"vm_post_create"`
+	VMPreStart   *Hook `toml:"vm_pre_start" json:"vm_pre_start"`
+	VMPostStart  *Hook `toml:"vm_post_start" json:"vm_post_start"`
+	VMPreDelete  *Hook `toml:"vm_pre_delete" json:"vm_pre_delete"`
+	VMPostDelete *Hook `toml:"vm_post_delete" json:"vm_post_delete"`
+}
+
+// Validate checks the hook command is a usable executable and normalizes the
+// timeout to the (0, DefaultHookTimeout] range.
+func (h *Hook) Validate() error {
+	if h == nil {
+		return nil
+	}
+	if h.Command == "" {
+		return fmt.Errorf("hook command is empty")
+	}
+	info, err := os.Stat(h.Command)
+	if err != nil {
+		return fmt.Errorf("hook command %q: %w", h.Command, err)
+	}
+	if info.IsDir() || info.Mode()&0o111 == 0 {
+		return fmt.Errorf("hook command %q is not an executable file", h.Command)
+	}
+	if h.Timeout <= 0 || h.Timeout > DefaultHookTimeout {
+		h.Timeout = DefaultHookTimeout
+	}
+	return nil
+}
+
+// Validate validates every configured hook.
+func (h *Hooks) Validate() error {
+	for _, hook := range []*Hook{
+		h.VMPreCreate, h.VMPostCreate, h.VMPreStart,
+		h.VMPostStart, h.VMPreDelete, h.VMPostDelete,
+	} {
+		if err := hook.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Incus holds connection information for an Incus cluster.
 type Incus struct {
 	// UnixSocket is the path on disk to the Incus unix socket. If defined,
@@ -118,6 +177,9 @@ type Incus struct {
 
 	// InstanceType allows you to choose between a virtual machine and a container
 	InstanceType IncusImageType `toml:"instance_type" json:"instance-type"`
+
+	// Hooks holds optional external commands run at instance lifecycle points.
+	Hooks Hooks `toml:"hooks" json:"hooks"`
 }
 
 func (l *Incus) GetInstanceType() IncusImageType {
@@ -130,6 +192,10 @@ func (l *Incus) GetInstanceType() IncusImageType {
 }
 
 func (l *Incus) Validate() error {
+	if err := l.Hooks.Validate(); err != nil {
+		return fmt.Errorf("validating hooks: %w", err)
+	}
+
 	if l.UnixSocket != "" {
 		if _, err := os.Stat(l.UnixSocket); err != nil {
 			return fmt.Errorf("could not access unix socket %s: %w", l.UnixSocket, err)

--- a/config/config.go
+++ b/config/config.go
@@ -88,18 +88,18 @@ const DefaultHookTimeout = 60
 // Command is a shell command line run via "/bin/sh -c".
 type Hook struct {
 	Command       string `toml:"command" json:"command"`
-	Timeout       int    `toml:"timeout" json:"timeout"`
-	IgnoreFailure bool   `toml:"ignore_failure" json:"ignore_failure"`
+	Timeout       int    `toml:"timeout" json:"timeout,omitempty"`
+	IgnoreFailure bool   `toml:"ignore_failure" json:"ignore_failure,omitempty"`
 }
 
 // Hooks groups the supported instance lifecycle hooks.
 type Hooks struct {
-	VMPreCreate  *Hook `toml:"vm_pre_create" json:"vm_pre_create"`
-	VMPostCreate *Hook `toml:"vm_post_create" json:"vm_post_create"`
-	VMPreStart   *Hook `toml:"vm_pre_start" json:"vm_pre_start"`
-	VMPostStart  *Hook `toml:"vm_post_start" json:"vm_post_start"`
-	VMPreDelete  *Hook `toml:"vm_pre_delete" json:"vm_pre_delete"`
-	VMPostDelete *Hook `toml:"vm_post_delete" json:"vm_post_delete"`
+	VMPreCreate  *Hook `toml:"vm_pre_create" json:"vm_pre_create,omitempty"`
+	VMPostCreate *Hook `toml:"vm_post_create" json:"vm_post_create,omitempty"`
+	VMPreStart   *Hook `toml:"vm_pre_start" json:"vm_pre_start,omitempty"`
+	VMPostStart  *Hook `toml:"vm_post_start" json:"vm_post_start,omitempty"`
+	VMPreDelete  *Hook `toml:"vm_pre_delete" json:"vm_pre_delete,omitempty"`
+	VMPostDelete *Hook `toml:"vm_post_delete" json:"vm_post_delete,omitempty"`
 }
 
 // Validate checks the hook has a command and normalizes the timeout to the
@@ -119,6 +119,9 @@ func (h *Hook) Validate() error {
 
 // Validate validates every configured hook.
 func (h *Hooks) Validate() error {
+	if h == nil {
+		return nil
+	}
 	for _, hook := range []*Hook{
 		h.VMPreCreate, h.VMPostCreate, h.VMPreStart,
 		h.VMPostStart, h.VMPreDelete, h.VMPostDelete,

--- a/config/incus_test.go
+++ b/config/incus_test.go
@@ -16,9 +16,7 @@
 package config
 
 import (
-	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -179,46 +177,29 @@ func TestInvalidIncusImageRemotes(t *testing.T) {
 	require.EqualError(t, err, "remote default is invalid: invalid remote protocol bogus. Supported protocols: simplestreams")
 }
 
-func writeExecFile(t *testing.T, mode os.FileMode) string {
-	t.Helper()
-	p := filepath.Join(t.TempDir(), "hook.sh")
-	require.NoError(t, os.WriteFile(p, []byte("#!/bin/sh\n"), mode))
-	return p
-}
-
 func TestHookValidateEmptyCommand(t *testing.T) {
 	require.EqualError(t, (&Hook{}).Validate(), "hook command is empty")
 }
 
-func TestHookValidateNonExecutable(t *testing.T) {
-	require.ErrorContains(t, (&Hook{Command: writeExecFile(t, 0o644)}).Validate(), "not an executable file")
-	require.ErrorContains(t, (&Hook{Command: t.TempDir()}).Validate(), "not an executable file")
-	require.Error(t, (&Hook{Command: "/does/not/exist"}).Validate())
-}
-
 func TestHookValidateTimeoutNormalize(t *testing.T) {
-	cmd := writeExecFile(t, 0o755)
 	for in, want := range map[int]int{0: DefaultHookTimeout, -5: DefaultHookTimeout, 600: DefaultHookTimeout, 30: 30} {
-		h := &Hook{Command: cmd, Timeout: in}
+		h := &Hook{Command: "true", Timeout: in}
 		require.NoError(t, h.Validate())
 		require.Equal(t, want, h.Timeout, "timeout=%d", in)
 	}
 }
 
 func TestConfigParsesHooks(t *testing.T) {
-	cmd := writeExecFile(t, 0o755)
 	var cfg Incus
-	_, err := toml.Decode(fmt.Sprintf(`
+	_, err := toml.Decode(`
 url = "https://example.com:8443"
 [hooks.vm_pre_create]
-command = %q
-args = ["--role", "builder"]
+command = "/opt/garm/hooks/vm-pre-create.sh --role builder"
 timeout = 30
-`, cmd), &cfg)
+`, &cfg)
 	require.NoError(t, err)
 	require.NotNil(t, cfg.Hooks.VMPreCreate)
-	require.Equal(t, cmd, cfg.Hooks.VMPreCreate.Command)
-	require.Equal(t, []string{"--role", "builder"}, cfg.Hooks.VMPreCreate.Args)
+	require.Equal(t, "/opt/garm/hooks/vm-pre-create.sh --role builder", cfg.Hooks.VMPreCreate.Command)
 	require.Equal(t, 30, cfg.Hooks.VMPreCreate.Timeout)
 	require.NoError(t, cfg.Hooks.Validate())
 }

--- a/config/incus_test.go
+++ b/config/incus_test.go
@@ -16,9 +16,12 @@
 package config
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/require"
 )
 
@@ -174,4 +177,48 @@ func TestInvalidIncusImageRemotes(t *testing.T) {
 	err := cfg.Validate()
 	require.NotNil(t, err)
 	require.EqualError(t, err, "remote default is invalid: invalid remote protocol bogus. Supported protocols: simplestreams")
+}
+
+func writeExecFile(t *testing.T, mode os.FileMode) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "hook.sh")
+	require.NoError(t, os.WriteFile(p, []byte("#!/bin/sh\n"), mode))
+	return p
+}
+
+func TestHookValidateEmptyCommand(t *testing.T) {
+	require.EqualError(t, (&Hook{}).Validate(), "hook command is empty")
+}
+
+func TestHookValidateNonExecutable(t *testing.T) {
+	require.ErrorContains(t, (&Hook{Command: writeExecFile(t, 0o644)}).Validate(), "not an executable file")
+	require.ErrorContains(t, (&Hook{Command: t.TempDir()}).Validate(), "not an executable file")
+	require.Error(t, (&Hook{Command: "/does/not/exist"}).Validate())
+}
+
+func TestHookValidateTimeoutNormalize(t *testing.T) {
+	cmd := writeExecFile(t, 0o755)
+	for in, want := range map[int]int{0: DefaultHookTimeout, -5: DefaultHookTimeout, 600: DefaultHookTimeout, 30: 30} {
+		h := &Hook{Command: cmd, Timeout: in}
+		require.NoError(t, h.Validate())
+		require.Equal(t, want, h.Timeout, "timeout=%d", in)
+	}
+}
+
+func TestConfigParsesHooks(t *testing.T) {
+	cmd := writeExecFile(t, 0o755)
+	var cfg Incus
+	_, err := toml.Decode(fmt.Sprintf(`
+url = "https://example.com:8443"
+[hooks.vm_pre_create]
+command = %q
+args = ["--role", "builder"]
+timeout = 30
+`, cmd), &cfg)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Hooks.VMPreCreate)
+	require.Equal(t, cmd, cfg.Hooks.VMPreCreate.Command)
+	require.Equal(t, []string{"--role", "builder"}, cfg.Hooks.VMPreCreate.Args)
+	require.Equal(t, 30, cfg.Hooks.VMPreCreate.Timeout)
+	require.NoError(t, cfg.Hooks.Validate())
 }

--- a/examples/hooks/vm-pre-create.sh
+++ b/examples/hooks/vm-pre-create.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# vm-pre-create: mutate the incus InstancesPost before the instance is created.
+#   stdin  = api.InstancesPost JSON
+#   stdout = modified api.InstancesPost JSON (must stay a complete, valid object)
+# Do NOT change identity fields (name / user.runner-* / user.os-* config keys).
+set -euo pipefail
+
+input="$(cat)"
+
+# Show the input on stderr (surfaced in the provider/garm logs).
+{
+    echo "[vm-pre-create] hook=${GARM_HOOK} phase=${GARM_HOOK_PHASE}"
+    echo "[vm-pre-create] instance=${GARM_INSTANCE_NAME} pool=${GARM_POOL_ID} arch=${GARM_OS_ARCH}"
+    printf '%s\n' "${input}" | jq .
+} >&2
+
+# Emit the modified InstancesPost: attach a data disk device.
+printf '%s' "${input}" | jq \
+    '.devices = ((.devices // {}) + {
+        "data": {"type": "disk", "pool": "default", "source": "vol-'"${GARM_INSTANCE_NAME}"'", "path": "/data"}
+    })'

--- a/examples/hooks/vm-pre-create.sh
+++ b/examples/hooks/vm-pre-create.sh
@@ -2,7 +2,7 @@
 # vm-pre-create: mutate the incus InstancesPost before the instance is created.
 #   stdin  = api.InstancesPost JSON
 #   stdout = modified api.InstancesPost JSON (must stay a complete, valid object)
-# Do NOT change identity fields (name / user.runner-* / user.os-* config keys).
+# Do NOT change the instance name (garm tracks the instance by it).
 set -euo pipefail
 
 input="$(cat)"

--- a/examples/hooks/vm-pre-delete.sh
+++ b/examples/hooks/vm-pre-delete.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# vm-pre-delete: runs before the instance is stopped/removed. Its disk still
+# exists here. stdin = instance-context JSON; stdout is ignored.
+# Must be idempotent: it may run for an already-gone instance (garm retries
+# failed creates), and a delete-hook failure never blocks deletion.
+set -euo pipefail
+
+ctx="$(cat)"
+{
+    echo "[vm-pre-delete] hook=${GARM_HOOK} phase=${GARM_HOOK_PHASE} ignore_failure=${GARM_HOOK_IGNORE_FAILURE}"
+    echo "[vm-pre-delete] instance=${GARM_INSTANCE_NAME} pool=${GARM_POOL_ID}"
+    printf '%s\n' "${ctx}" | jq .
+} >&2
+
+# Do host-side work keyed on ${GARM_INSTANCE_NAME} / ${GARM_POOL_ID} here,
+# e.g. snapshot the instance disk before it is removed.

--- a/provider/hooks.go
+++ b/provider/hooks.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 Cloudbase Solutions SRL
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/cloudbase/garm-provider-incus/config"
+)
+
+type hookPhase string
+
+const (
+	hookPhaseCreate hookPhase = "create"
+	hookPhaseStart  hookPhase = "start"
+	hookPhaseDelete hookPhase = "delete"
+)
+
+// hookContext is passed to hooks as JSON on stdin and mirrored into env vars.
+type hookContext struct {
+	Name         string `json:"name"`
+	ControllerID string `json:"controller_id"`
+	PoolID       string `json:"pool_id"`
+	OSType       string `json:"os_type"`
+	OSArch       string `json:"os_arch"`
+	InstanceType string `json:"instance_type"`
+}
+
+// effectiveHookTimeout returns the timeout clamped to (0, cap].
+func effectiveHookTimeout(hook *config.Hook) time.Duration {
+	t := time.Duration(hook.Timeout) * time.Second
+	if t <= 0 || t > config.DefaultHookTimeout*time.Second {
+		return config.DefaultHookTimeout * time.Second
+	}
+	return t
+}
+
+// runHook execs hook (nil/empty command = no-op returning stdin) and returns stdout.
+func runHook(ctx context.Context, hook *config.Hook, hookName string, phase hookPhase, hc hookContext, stdin []byte) ([]byte, error) {
+	if hook == nil || hook.Command == "" {
+		return stdin, nil
+	}
+
+	timeout := effectiveHookTimeout(hook)
+	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(cmdCtx, hook.Command, hook.Args...)
+	cmd.Env = append(os.Environ(),
+		"GARM_HOOK="+hookName,
+		"GARM_HOOK_PHASE="+string(phase),
+		"GARM_INSTANCE_NAME="+hc.Name,
+		"GARM_POOL_ID="+hc.PoolID,
+		"GARM_CONTROLLER_ID="+hc.ControllerID,
+		"GARM_OS_TYPE="+hc.OSType,
+		"GARM_OS_ARCH="+hc.OSArch,
+		"GARM_INSTANCE_TYPE="+hc.InstanceType,
+		fmt.Sprintf("GARM_HOOK_IGNORE_FAILURE=%t", hook.IgnoreFailure),
+	)
+	if stdin != nil {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if cmdCtx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("hook %q timed out after %s: %s", hookName, timeout, stderr.String())
+		}
+		return nil, fmt.Errorf("hook %q failed: %w: %s", hookName, err, stderr.String())
+	}
+	return stdout.Bytes(), nil
+}
+
+// runSideEffectHook runs a hook (stdout ignored); errors only when ignore_failure is false.
+func runSideEffectHook(ctx context.Context, hook *config.Hook, hookName string, phase hookPhase, hc hookContext) error {
+	if hook == nil || hook.Command == "" {
+		return nil
+	}
+	stdin, err := json.Marshal(hc)
+	if err != nil {
+		return fmt.Errorf("marshaling hook context: %w", err)
+	}
+	if _, err := runHook(ctx, hook, hookName, phase, hc, stdin); err != nil {
+		if hook.IgnoreFailure {
+			fmt.Fprintf(os.Stderr, "ignoring hook %q failure: %v\n", hookName, err)
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/provider/hooks.go
+++ b/provider/hooks.go
@@ -64,7 +64,7 @@ func runHook(ctx context.Context, hook *config.Hook, hookName string, phase hook
 	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(cmdCtx, hook.Command, hook.Args...)
+	cmd := exec.CommandContext(cmdCtx, "/bin/sh", "-c", hook.Command)
 	cmd.Env = append(os.Environ(),
 		"GARM_HOOK="+hookName,
 		"GARM_HOOK_PHASE="+string(phase),

--- a/provider/hooks_test.go
+++ b/provider/hooks_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 Cloudbase Solutions SRL
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+package provider
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cloudbase/garm-provider-incus/config"
+	"github.com/stretchr/testify/require"
+)
+
+// writeExecScript writes body to an executable /bin/sh script and returns its path.
+func writeExecScript(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "hook.sh")
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755))
+	return path
+}
+
+func TestEffectiveHookTimeout(t *testing.T) {
+	cases := map[int]time.Duration{
+		0:   config.DefaultHookTimeout * time.Second,
+		-5:  config.DefaultHookTimeout * time.Second,
+		600: config.DefaultHookTimeout * time.Second,
+		30:  30 * time.Second,
+		60:  60 * time.Second,
+	}
+	for in, want := range cases {
+		require.Equal(t, want, effectiveHookTimeout(&config.Hook{Timeout: in}), "timeout=%d", in)
+	}
+}
+
+func TestRunHookStdinStdout(t *testing.T) {
+	hook := &config.Hook{Command: writeExecScript(t, "cat")}
+	out, err := runHook(context.Background(), hook, "vm_pre_create", hookPhaseCreate, hookContext{}, []byte("payload"))
+	require.NoError(t, err)
+	require.Equal(t, "payload", string(out))
+}
+
+func TestRunHookEnv(t *testing.T) {
+	hook := &config.Hook{Command: writeExecScript(t,
+		`printf '%s|%s|%s|%s|%s|%s|%s|%s|%s' "$GARM_HOOK" "$GARM_HOOK_PHASE" "$GARM_INSTANCE_NAME" "$GARM_POOL_ID" "$GARM_CONTROLLER_ID" "$GARM_OS_TYPE" "$GARM_OS_ARCH" "$GARM_INSTANCE_TYPE" "$GARM_HOOK_IGNORE_FAILURE"`),
+		IgnoreFailure: true,
+	}
+	hc := hookContext{Name: "inst", ControllerID: "ctrl", PoolID: "pool", OSType: "linux", OSArch: "amd64", InstanceType: "virtual-machine"}
+	out, err := runHook(context.Background(), hook, "vm_post_start", hookPhaseStart, hc, nil)
+	require.NoError(t, err)
+	require.Equal(t, "vm_post_start|start|inst|pool|ctrl|linux|amd64|virtual-machine|true", string(out))
+}
+
+func TestRunHookNonZeroExit(t *testing.T) {
+	hook := &config.Hook{Command: writeExecScript(t, "echo boom >&2; exit 1")}
+	_, err := runHook(context.Background(), hook, "vm_pre_start", hookPhaseStart, hookContext{}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "boom")
+}
+
+func TestRunHookTimeout(t *testing.T) {
+	hook := &config.Hook{Command: writeExecScript(t, "sleep 3"), Timeout: 1}
+	_, err := runHook(context.Background(), hook, "vm_post_start", hookPhaseStart, hookContext{}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timed out")
+}
+
+func TestRunHookNilOrEmpty(t *testing.T) {
+	out, err := runHook(context.Background(), nil, "vm_pre_create", hookPhaseCreate, hookContext{}, []byte("keep"))
+	require.NoError(t, err)
+	require.Equal(t, "keep", string(out))
+
+	out, err = runHook(context.Background(), &config.Hook{}, "vm_pre_create", hookPhaseCreate, hookContext{}, []byte("keep"))
+	require.NoError(t, err)
+	require.Equal(t, "keep", string(out))
+}
+
+func TestRunSideEffectHookIgnoreFailure(t *testing.T) {
+	fail := writeExecScript(t, "exit 1")
+
+	require.NoError(t, runSideEffectHook(context.Background(),
+		&config.Hook{Command: fail, IgnoreFailure: true}, "vm_pre_delete", hookPhaseDelete, hookContext{}))
+
+	require.Error(t, runSideEffectHook(context.Background(),
+		&config.Hook{Command: fail, IgnoreFailure: false}, "vm_post_create", hookPhaseCreate, hookContext{}))
+
+	require.NoError(t, runSideEffectHook(context.Background(), nil, "vm_post_create", hookPhaseCreate, hookContext{}))
+}

--- a/provider/hooks_test.go
+++ b/provider/hooks_test.go
@@ -17,22 +17,12 @@ package provider
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/cloudbase/garm-provider-incus/config"
 	"github.com/stretchr/testify/require"
 )
-
-// writeExecScript writes body to an executable /bin/sh script and returns its path.
-func writeExecScript(t *testing.T, body string) string {
-	t.Helper()
-	path := filepath.Join(t.TempDir(), "hook.sh")
-	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755))
-	return path
-}
 
 func TestEffectiveHookTimeout(t *testing.T) {
 	cases := map[int]time.Duration{
@@ -48,15 +38,14 @@ func TestEffectiveHookTimeout(t *testing.T) {
 }
 
 func TestRunHookStdinStdout(t *testing.T) {
-	hook := &config.Hook{Command: writeExecScript(t, "cat")}
-	out, err := runHook(context.Background(), hook, "vm_pre_create", hookPhaseCreate, hookContext{}, []byte("payload"))
+	out, err := runHook(context.Background(), &config.Hook{Command: "cat"}, "vm_pre_create", hookPhaseCreate, hookContext{}, []byte("payload"))
 	require.NoError(t, err)
 	require.Equal(t, "payload", string(out))
 }
 
 func TestRunHookEnv(t *testing.T) {
-	hook := &config.Hook{Command: writeExecScript(t,
-		`printf '%s|%s|%s|%s|%s|%s|%s|%s|%s' "$GARM_HOOK" "$GARM_HOOK_PHASE" "$GARM_INSTANCE_NAME" "$GARM_POOL_ID" "$GARM_CONTROLLER_ID" "$GARM_OS_TYPE" "$GARM_OS_ARCH" "$GARM_INSTANCE_TYPE" "$GARM_HOOK_IGNORE_FAILURE"`),
+	hook := &config.Hook{
+		Command:       `printf '%s|%s|%s|%s|%s|%s|%s|%s|%s' "$GARM_HOOK" "$GARM_HOOK_PHASE" "$GARM_INSTANCE_NAME" "$GARM_POOL_ID" "$GARM_CONTROLLER_ID" "$GARM_OS_TYPE" "$GARM_OS_ARCH" "$GARM_INSTANCE_TYPE" "$GARM_HOOK_IGNORE_FAILURE"`,
 		IgnoreFailure: true,
 	}
 	hc := hookContext{Name: "inst", ControllerID: "ctrl", PoolID: "pool", OSType: "linux", OSArch: "amd64", InstanceType: "virtual-machine"}
@@ -66,15 +55,13 @@ func TestRunHookEnv(t *testing.T) {
 }
 
 func TestRunHookNonZeroExit(t *testing.T) {
-	hook := &config.Hook{Command: writeExecScript(t, "echo boom >&2; exit 1")}
-	_, err := runHook(context.Background(), hook, "vm_pre_start", hookPhaseStart, hookContext{}, nil)
+	_, err := runHook(context.Background(), &config.Hook{Command: "echo boom >&2; exit 1"}, "vm_pre_start", hookPhaseStart, hookContext{}, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "boom")
 }
 
 func TestRunHookTimeout(t *testing.T) {
-	hook := &config.Hook{Command: writeExecScript(t, "sleep 3"), Timeout: 1}
-	_, err := runHook(context.Background(), hook, "vm_post_start", hookPhaseStart, hookContext{}, nil)
+	_, err := runHook(context.Background(), &config.Hook{Command: "sleep 3", Timeout: 1}, "vm_post_start", hookPhaseStart, hookContext{}, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "timed out")
 }
@@ -90,13 +77,11 @@ func TestRunHookNilOrEmpty(t *testing.T) {
 }
 
 func TestRunSideEffectHookIgnoreFailure(t *testing.T) {
-	fail := writeExecScript(t, "exit 1")
-
 	require.NoError(t, runSideEffectHook(context.Background(),
-		&config.Hook{Command: fail, IgnoreFailure: true}, "vm_pre_delete", hookPhaseDelete, hookContext{}))
+		&config.Hook{Command: "exit 1", IgnoreFailure: true}, "vm_pre_delete", hookPhaseDelete, hookContext{}))
 
 	require.Error(t, runSideEffectHook(context.Background(),
-		&config.Hook{Command: fail, IgnoreFailure: false}, "vm_post_create", hookPhaseCreate, hookContext{}))
+		&config.Hook{Command: "exit 1", IgnoreFailure: false}, "vm_post_create", hookPhaseCreate, hookContext{}))
 
 	require.NoError(t, runSideEffectHook(context.Background(), nil, "vm_post_create", hookPhaseCreate, hookContext{}))
 }

--- a/provider/incus.go
+++ b/provider/incus.go
@@ -373,6 +373,9 @@ func (l *Incus) CreateInstance(ctx context.Context, bootstrapParams commonParams
 			if err := json.Unmarshal(out, &mutated); err != nil {
 				return commonParams.ProviderInstance{}, errors.Wrap(err, "unmarshaling vm_pre_create hook output")
 			}
+			if mutated.Name != args.Name {
+				return commonParams.ProviderInstance{}, fmt.Errorf("vm_pre_create hook must not change the instance name (%q -> %q)", args.Name, mutated.Name)
+			}
 			args = mutated
 		}
 	}

--- a/provider/incus.go
+++ b/provider/incus.go
@@ -17,7 +17,9 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -255,7 +257,7 @@ func (l *Incus) getCreateInstanceArgs(ctx context.Context, bootstrapParams commo
 	return args, nil
 }
 
-func (l *Incus) launchInstance(ctx context.Context, createArgs api.InstancesPost) error {
+func (l *Incus) launchInstance(ctx context.Context, createArgs api.InstancesPost, hc hookContext) error {
 	cli, err := l.getCLI(ctx)
 	if err != nil {
 		return errors.Wrap(err, "fetching client")
@@ -272,6 +274,15 @@ func (l *Incus) launchInstance(ctx context.Context, createArgs api.InstancesPost
 		return errors.Wrap(err, "waiting for instance creation")
 	}
 
+	if err := runSideEffectHook(ctx, l.cfg.Hooks.VMPostCreate, "vm_post_create", hookPhaseCreate, hc); err != nil {
+		l.cleanupFailedInstance(ctx, createArgs.Name)
+		return errors.Wrap(err, "vm_post_create hook")
+	}
+	if err := runSideEffectHook(ctx, l.cfg.Hooks.VMPreStart, "vm_pre_start", hookPhaseStart, hc); err != nil {
+		l.cleanupFailedInstance(ctx, createArgs.Name)
+		return errors.Wrap(err, "vm_pre_start hook")
+	}
+
 	// Get Incus to start the instance (background operation)
 	reqState := api.InstanceStatePut{
 		Action:  "start",
@@ -280,15 +291,57 @@ func (l *Incus) launchInstance(ctx context.Context, createArgs api.InstancesPost
 
 	op, err = cli.UpdateInstanceState(createArgs.Name, reqState, "")
 	if err != nil {
+		l.cleanupFailedInstance(ctx, createArgs.Name)
 		return errors.Wrap(err, "starting instance")
 	}
 
 	// Wait for the operation to complete
 	err = op.Wait()
 	if err != nil {
+		l.cleanupFailedInstance(ctx, createArgs.Name)
 		return errors.Wrap(err, "waiting for instance to start")
 	}
 	return nil
+}
+
+func hookContextFromBootstrap(bootstrapParams commonParams.BootstrapInstance, controllerID string, instanceType config.IncusImageType) hookContext {
+	return hookContext{
+		Name:         bootstrapParams.Name,
+		ControllerID: controllerID,
+		PoolID:       bootstrapParams.PoolID,
+		OSType:       string(bootstrapParams.OSType),
+		OSArch:       string(bootstrapParams.OSArch),
+		InstanceType: string(instanceType),
+	}
+}
+
+// hookContextForInstance builds a best-effort context (delete time; name only).
+func (l *Incus) hookContextForInstance(ctx context.Context, name string) hookContext {
+	hc := hookContext{Name: name, ControllerID: l.controllerID, InstanceType: string(l.cfg.GetInstanceType())}
+	cli, err := l.getCLI(ctx)
+	if err != nil {
+		return hc
+	}
+	full, _, err := cli.GetInstanceFull(name)
+	if err != nil {
+		return hc
+	}
+	hc.PoolID = full.ExpandedConfig[poolIDKey]
+	hc.OSArch = string(incusToConfigArch[full.Architecture])
+	incusOS := full.ExpandedConfig["image.os"]
+	osType, _ := util.OSToOSType(incusOS)
+	if osType == "" {
+		osType = commonParams.OSType(full.ExpandedConfig[osTypeKeyName])
+	}
+	hc.OSType = string(osType)
+	return hc
+}
+
+// cleanupFailedInstance removes an instance without running delete hooks.
+func (l *Incus) cleanupFailedInstance(ctx context.Context, name string) {
+	if err := l.deleteInstanceRaw(ctx, name); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to clean up instance %s after hook failure: %v\n", name, err)
+	}
 }
 
 // CreateInstance creates a new compute instance in the provider.
@@ -302,13 +355,42 @@ func (l *Incus) CreateInstance(ctx context.Context, bootstrapParams commonParams
 		return commonParams.ProviderInstance{}, errors.Wrap(err, "fetching create args")
 	}
 
-	if err := l.launchInstance(ctx, args); err != nil {
+	hc := hookContextFromBootstrap(bootstrapParams, l.controllerID, l.cfg.GetInstanceType())
+
+	if hook := l.cfg.Hooks.VMPreCreate; hook != nil {
+		payload, err := json.Marshal(args)
+		if err != nil {
+			return commonParams.ProviderInstance{}, errors.Wrap(err, "marshaling create args for vm_pre_create hook")
+		}
+		out, err := runHook(ctx, hook, "vm_pre_create", hookPhaseCreate, hc, payload)
+		if err != nil {
+			if !hook.IgnoreFailure {
+				return commonParams.ProviderInstance{}, errors.Wrap(err, "vm_pre_create hook")
+			}
+			fmt.Fprintf(os.Stderr, "ignoring vm_pre_create hook failure: %v\n", err)
+		} else if len(out) > 0 {
+			var mutated api.InstancesPost
+			if err := json.Unmarshal(out, &mutated); err != nil {
+				return commonParams.ProviderInstance{}, errors.Wrap(err, "unmarshaling vm_pre_create hook output")
+			}
+			args = mutated
+		}
+	}
+
+	if err := l.launchInstance(ctx, args, hc); err != nil {
 		return commonParams.ProviderInstance{}, errors.Wrap(err, "creating instance")
 	}
 
 	ret, err := l.waitInstanceHasIP(ctx, args.Name)
 	if err != nil {
-		return commonParams.ProviderInstance{}, errors.Wrap(err, "fetching instance")
+		l.cleanupFailedInstance(ctx, args.Name)
+		return commonParams.ProviderInstance{}, errors.Wrap(err, "waiting for instance IP")
+	}
+
+	// vm_post_start: instance has an IPv4, i.e. the incus-agent is reachable.
+	if err := runSideEffectHook(ctx, l.cfg.Hooks.VMPostStart, "vm_post_start", hookPhaseStart, hc); err != nil {
+		l.cleanupFailedInstance(ctx, args.Name)
+		return commonParams.ProviderInstance{}, errors.Wrap(err, "vm_post_start hook")
 	}
 
 	return ret, nil
@@ -331,8 +413,30 @@ func (l *Incus) GetInstance(ctx context.Context, instanceName string) (commonPar
 	return incusInstanceToAPIInstance(instance), nil
 }
 
-// Delete instance will delete the instance in a provider.
+// DeleteInstance deletes the instance, running vm_pre_delete/vm_post_delete
+// around it. With no delete hook it is identical to deleteInstanceRaw.
 func (l *Incus) DeleteInstance(ctx context.Context, instance string) error {
+	hooks := l.cfg.Hooks
+	if hooks.VMPreDelete == nil && hooks.VMPostDelete == nil {
+		return l.deleteInstanceRaw(ctx, instance)
+	}
+
+	hc := l.hookContextForInstance(ctx, instance)
+
+	if err := runSideEffectHook(ctx, hooks.VMPreDelete, "vm_pre_delete", hookPhaseDelete, hc); err != nil {
+		fmt.Fprintf(os.Stderr, "vm_pre_delete hook failed for %s; continuing: %v\n", instance, err)
+	}
+	if err := l.deleteInstanceRaw(ctx, instance); err != nil {
+		return err
+	}
+	if err := runSideEffectHook(ctx, hooks.VMPostDelete, "vm_post_delete", hookPhaseDelete, hc); err != nil {
+		fmt.Fprintf(os.Stderr, "vm_post_delete hook failed for %s: %v\n", instance, err)
+	}
+	return nil
+}
+
+// deleteInstanceRaw stops and removes the instance without running hooks.
+func (l *Incus) deleteInstanceRaw(ctx context.Context, instance string) error {
 	cli, err := l.getCLI(ctx)
 	if err != nil {
 		return errors.Wrap(err, "fetching client")

--- a/provider/incus.go
+++ b/provider/incus.go
@@ -55,6 +55,10 @@ const (
 	// architecture a runner is supposed to have. This value is defined in the pool and
 	// passed into the provider as bootstrap params.
 	osArchKeyNAme = "user.os-arch"
+
+	// deleteHooksKeyName persists the resolved delete hooks on the instance so
+	// DeleteInstance can recover them (garm does not pass extra_specs at delete).
+	deleteHooksKeyName = "user.garm-incus-delete-hooks"
 )
 
 var (
@@ -257,7 +261,7 @@ func (l *Incus) getCreateInstanceArgs(ctx context.Context, bootstrapParams commo
 	return args, nil
 }
 
-func (l *Incus) launchInstance(ctx context.Context, createArgs api.InstancesPost, hc hookContext) error {
+func (l *Incus) launchInstance(ctx context.Context, createArgs api.InstancesPost, hc hookContext, hooks config.Hooks) error {
 	cli, err := l.getCLI(ctx)
 	if err != nil {
 		return errors.Wrap(err, "fetching client")
@@ -274,11 +278,11 @@ func (l *Incus) launchInstance(ctx context.Context, createArgs api.InstancesPost
 		return errors.Wrap(err, "waiting for instance creation")
 	}
 
-	if err := runSideEffectHook(ctx, l.cfg.Hooks.VMPostCreate, "vm_post_create", hookPhaseCreate, hc); err != nil {
+	if err := runSideEffectHook(ctx, hooks.VMPostCreate, "vm_post_create", hookPhaseCreate, hc); err != nil {
 		l.cleanupFailedInstance(ctx, createArgs.Name)
 		return errors.Wrap(err, "vm_post_create hook")
 	}
-	if err := runSideEffectHook(ctx, l.cfg.Hooks.VMPreStart, "vm_pre_start", hookPhaseStart, hc); err != nil {
+	if err := runSideEffectHook(ctx, hooks.VMPreStart, "vm_pre_start", hookPhaseStart, hc); err != nil {
 		l.cleanupFailedInstance(ctx, createArgs.Name)
 		return errors.Wrap(err, "vm_pre_start hook")
 	}
@@ -315,17 +319,8 @@ func hookContextFromBootstrap(bootstrapParams commonParams.BootstrapInstance, co
 	}
 }
 
-// hookContextForInstance builds a best-effort context (delete time; name only).
-func (l *Incus) hookContextForInstance(ctx context.Context, name string) hookContext {
+func (l *Incus) hookContextFromFull(name string, full *api.InstanceFull) hookContext {
 	hc := hookContext{Name: name, ControllerID: l.controllerID, InstanceType: string(l.cfg.GetInstanceType())}
-	cli, err := l.getCLI(ctx)
-	if err != nil {
-		return hc
-	}
-	full, _, err := cli.GetInstanceFull(name)
-	if err != nil {
-		return hc
-	}
 	hc.PoolID = full.ExpandedConfig[poolIDKey]
 	hc.OSArch = string(incusToConfigArch[full.Architecture])
 	incusOS := full.ExpandedConfig["image.os"]
@@ -335,6 +330,44 @@ func (l *Incus) hookContextForInstance(ctx context.Context, name string) hookCon
 	}
 	hc.OSType = string(osType)
 	return hc
+}
+
+// instanceDeleteHooks is the delete-hook subset persisted on the instance.
+type instanceDeleteHooks struct {
+	VMPreDelete  *config.Hook `json:"vm_pre_delete,omitempty"`
+	VMPostDelete *config.Hook `json:"vm_post_delete,omitempty"`
+}
+
+// resolveDeleteHooks returns an instance's delete hooks: the per-instance set
+// persisted from extra_specs if present, otherwise the config hooks. ok is
+// false only when the instance is gone (not found), in which case no hooks run.
+func (l *Incus) resolveDeleteHooks(ctx context.Context, name string) (pre, post *config.Hook, hc hookContext, ok bool) {
+	hc = hookContext{Name: name, ControllerID: l.controllerID, InstanceType: string(l.cfg.GetInstanceType())}
+	cli, err := l.getCLI(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fetching client for delete hooks of %s; using config hooks: %v\n", name, err)
+		return l.cfg.Hooks.VMPreDelete, l.cfg.Hooks.VMPostDelete, hc, true
+	}
+	full, _, err := cli.GetInstanceFull(name)
+	if err != nil {
+		if isNotFoundError(err) {
+			return nil, nil, hc, false
+		}
+		fmt.Fprintf(os.Stderr, "reading instance %s for delete hooks; using config hooks: %v\n", name, err)
+		return l.cfg.Hooks.VMPreDelete, l.cfg.Hooks.VMPostDelete, hc, true
+	}
+	hc = l.hookContextFromFull(name, full)
+	if raw, present := full.ExpandedConfig[deleteHooksKeyName]; present {
+		var dh instanceDeleteHooks
+		if err := json.Unmarshal([]byte(raw), &dh); err != nil {
+			// The key's presence means extra_specs replaced config; a corrupt
+			// value is unrecoverable, so skip rather than leak config hooks.
+			fmt.Fprintf(os.Stderr, "parsing persisted delete hooks for %s; skipping delete hooks: %v\n", name, err)
+			return nil, nil, hc, true
+		}
+		return dh.VMPreDelete, dh.VMPostDelete, hc, true
+	}
+	return l.cfg.Hooks.VMPreDelete, l.cfg.Hooks.VMPostDelete, hc, true
 }
 
 // cleanupFailedInstance removes an instance without running delete hooks.
@@ -357,7 +390,12 @@ func (l *Incus) CreateInstance(ctx context.Context, bootstrapParams commonParams
 
 	hc := hookContextFromBootstrap(bootstrapParams, l.controllerID, l.cfg.GetInstanceType())
 
-	if hook := l.cfg.Hooks.VMPreCreate; hook != nil {
+	hooks := l.cfg.Hooks
+	if extraSpecs.Hooks != nil {
+		hooks = *extraSpecs.Hooks
+	}
+
+	if hook := hooks.VMPreCreate; hook != nil {
 		payload, err := json.Marshal(args)
 		if err != nil {
 			return commonParams.ProviderInstance{}, errors.Wrap(err, "marshaling create args for vm_pre_create hook")
@@ -380,7 +418,18 @@ func (l *Incus) CreateInstance(ctx context.Context, bootstrapParams commonParams
 		}
 	}
 
-	if err := l.launchInstance(ctx, args, hc); err != nil {
+	if extraSpecs.Hooks != nil {
+		payload, err := json.Marshal(instanceDeleteHooks{hooks.VMPreDelete, hooks.VMPostDelete})
+		if err != nil {
+			return commonParams.ProviderInstance{}, errors.Wrap(err, "marshaling delete hooks")
+		}
+		if args.Config == nil {
+			args.Config = map[string]string{}
+		}
+		args.Config[deleteHooksKeyName] = string(payload)
+	}
+
+	if err := l.launchInstance(ctx, args, hc, hooks); err != nil {
 		return commonParams.ProviderInstance{}, errors.Wrap(err, "creating instance")
 	}
 
@@ -391,7 +440,7 @@ func (l *Incus) CreateInstance(ctx context.Context, bootstrapParams commonParams
 	}
 
 	// vm_post_start: instance has an IPv4, i.e. the incus-agent is reachable.
-	if err := runSideEffectHook(ctx, l.cfg.Hooks.VMPostStart, "vm_post_start", hookPhaseStart, hc); err != nil {
+	if err := runSideEffectHook(ctx, hooks.VMPostStart, "vm_post_start", hookPhaseStart, hc); err != nil {
 		l.cleanupFailedInstance(ctx, args.Name)
 		return commonParams.ProviderInstance{}, errors.Wrap(err, "vm_post_start hook")
 	}
@@ -416,23 +465,21 @@ func (l *Incus) GetInstance(ctx context.Context, instanceName string) (commonPar
 	return incusInstanceToAPIInstance(instance), nil
 }
 
-// DeleteInstance deletes the instance, running vm_pre_delete/vm_post_delete
-// around it. With no delete hook it is identical to deleteInstanceRaw.
+// DeleteInstance deletes the instance, running its resolved
+// vm_pre_delete/vm_post_delete hooks around the removal.
 func (l *Incus) DeleteInstance(ctx context.Context, instance string) error {
-	hooks := l.cfg.Hooks
-	if hooks.VMPreDelete == nil && hooks.VMPostDelete == nil {
+	pre, post, hc, ok := l.resolveDeleteHooks(ctx, instance)
+	if !ok || (pre == nil && post == nil) {
 		return l.deleteInstanceRaw(ctx, instance)
 	}
 
-	hc := l.hookContextForInstance(ctx, instance)
-
-	if err := runSideEffectHook(ctx, hooks.VMPreDelete, "vm_pre_delete", hookPhaseDelete, hc); err != nil {
+	if err := runSideEffectHook(ctx, pre, "vm_pre_delete", hookPhaseDelete, hc); err != nil {
 		fmt.Fprintf(os.Stderr, "vm_pre_delete hook failed for %s; continuing: %v\n", instance, err)
 	}
 	if err := l.deleteInstanceRaw(ctx, instance); err != nil {
 		return err
 	}
-	if err := runSideEffectHook(ctx, hooks.VMPostDelete, "vm_post_delete", hookPhaseDelete, hc); err != nil {
+	if err := runSideEffectHook(ctx, post, "vm_post_delete", hookPhaseDelete, hc); err != nil {
 		fmt.Fprintf(os.Stderr, "vm_post_delete hook failed for %s: %v\n", instance, err)
 	}
 	return nil

--- a/provider/incus_test.go
+++ b/provider/incus_test.go
@@ -17,6 +17,8 @@ package provider
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	commonParams "github.com/cloudbase/garm-provider-common/params"
@@ -378,7 +380,7 @@ func TestLaunchInstance(t *testing.T) {
 		Timeout: -1,
 	}, "").Return(mockOp, nil)
 
-	err := l.launchInstance(ctx, createArgs)
+	err := l.launchInstance(ctx, createArgs, hookContext{})
 	require.NoError(t, err)
 }
 
@@ -772,4 +774,227 @@ func TestStart(t *testing.T) {
 	}, "").Return(mockOp, nil)
 	err := l.Start(ctx, instanceName)
 	require.NoError(t, err)
+}
+
+// --- lifecycle hooks --------------------------------------------------------
+
+func newHookProvider(cli InstanceServerInterface, hooks config.Hooks) *Incus {
+	return &Incus{
+		cfg: &config.Incus{
+			UnixSocket:            "/var/run/incus.sock",
+			InstanceType:          "virtual-machine",
+			IncludeDefaultProfile: true,
+			Hooks:                 hooks,
+		},
+		cli:          cli,
+		imageManager: &image{remotes: map[string]config.IncusImageRemote{"remote1": {Address: "remote1"}}},
+		controllerID: "controller",
+	}
+}
+
+func hookBootstrap() commonParams.BootstrapInstance {
+	return commonParams.BootstrapInstance{
+		Name:   "test-instance",
+		Tools:  []commonParams.RunnerApplicationDownload{{OS: ptr("linux"), Architecture: ptr("x86_64"), DownloadURL: ptr("https://example.com"), Filename: ptr("test-app")}},
+		Image:  "linux",
+		Flavor: "virtual-machine",
+		PoolID: "default",
+		OSArch: commonParams.Amd64,
+		OSType: commonParams.Linux,
+	}
+}
+
+// setupCreateFlow stubs the calls getCreateInstanceArgs+launchInstance make and
+// returns a shared operation. CreateInstance/UpdateInstanceState are left to the
+// caller so per-test capture/matchers are possible.
+func setupCreateFlow(cli *MockIncusServer) *MockOperation {
+	DefaultToolFetch = func(_ commonParams.OSType, _ commonParams.OSArch, tools []commonParams.RunnerApplicationDownload) (commonParams.RunnerApplicationDownload, error) {
+		return tools[0], nil
+	}
+	DefaultGetCloudconfig = func(_ commonParams.BootstrapInstance, _ commonParams.RunnerApplicationDownload, _ string) (string, error) {
+		return "#cloud-config", nil
+	}
+	aliases := map[string]*api.ImageAliasesEntry{"x86_64": {Name: "linux", Type: "virtual-machine"}}
+	cli.On("GetImageAliasArchitectures", config.IncusImageType("virtual-machine").String(), "linux").Return(aliases, nil)
+	cli.On("GetImage", aliases["x86_64"].Target).Return(&api.Image{Fingerprint: "123abc"}, "", nil)
+	cli.On("GetProfileNames").Return([]string{"default", "virtual-machine"}, nil)
+	op := new(MockOperation)
+	op.On("Wait").Return(nil)
+	op.On("WaitContext", mock.Anything).Return(nil)
+	return op
+}
+
+func mockInstanceWithIP(cli *MockIncusServer) {
+	cli.On("GetInstanceFull", "test-instance").Return(&api.InstanceFull{
+		Instance: api.Instance{
+			InstancePut:    api.InstancePut{Architecture: "x86_64"},
+			Name:           "test-instance",
+			ExpandedConfig: map[string]string{"image.os": "ubuntu", poolIDKey: "default", osTypeKeyName: "linux"},
+			Type:           "virtual-machine",
+		},
+		State: &api.InstanceState{
+			Status:  "Running",
+			Network: map[string]api.InstanceStateNetwork{"eth0": {Addresses: []api.InstanceStateNetworkAddress{{Address: "10.10.0.0", Scope: "global"}}}},
+		},
+	}, "", nil)
+}
+
+// markerHook returns a hook whose script appends $GARM_HOOK to the marker file
+// (passed as arg $1) and writes nothing to stdout.
+func markerHook(t *testing.T, marker string) *config.Hook {
+	return &config.Hook{Command: writeExecScript(t, `printf '%s ' "$GARM_HOOK" >> "$1"`), Args: []string{marker}}
+}
+
+func TestCreateInstanceRunsHooksInOrder(t *testing.T) {
+	ctx := context.Background()
+	cli := new(MockIncusServer)
+	marker := filepath.Join(t.TempDir(), "order")
+	l := newHookProvider(cli, config.Hooks{
+		VMPreCreate:  markerHook(t, marker),
+		VMPostCreate: markerHook(t, marker),
+		VMPreStart:   markerHook(t, marker),
+		VMPostStart:  markerHook(t, marker),
+	})
+	op := setupCreateFlow(cli)
+	cli.On("CreateInstance", mock.Anything).Return(op, nil)
+	cli.On("UpdateInstanceState", "test-instance", mock.Anything, "").Return(op, nil)
+	mockInstanceWithIP(cli)
+
+	_, err := l.CreateInstance(ctx, hookBootstrap())
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(marker)
+	require.NoError(t, err)
+	require.Equal(t, "vm_pre_create vm_post_create vm_pre_start vm_post_start ", string(got))
+}
+
+func TestCreateInstancePreCreateMutation(t *testing.T) {
+	ctx := context.Background()
+	cli := new(MockIncusServer)
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "out.json")
+	require.NoError(t, os.WriteFile(jsonPath, []byte(`{"name":"test-instance","architecture":"x86_64","description":"mutated-by-hook","type":"virtual-machine","source":{"type":"image","fingerprint":"123abc"},"profiles":["default","virtual-machine"],"config":{"user.runner-pool-id":"default"}}`), 0o644))
+	script := filepath.Join(dir, "hook.sh")
+	require.NoError(t, os.WriteFile(script, []byte("#!/bin/sh\ncat >/dev/null; cat \"$1\"\n"), 0o755))
+
+	l := newHookProvider(cli, config.Hooks{VMPreCreate: &config.Hook{Command: script, Args: []string{jsonPath}}})
+	op := setupCreateFlow(cli)
+	var got api.InstancesPost
+	cli.On("CreateInstance", mock.Anything).Run(func(a mock.Arguments) { got = a.Get(0).(api.InstancesPost) }).Return(op, nil)
+	cli.On("UpdateInstanceState", "test-instance", mock.Anything, "").Return(op, nil)
+	mockInstanceWithIP(cli)
+
+	_, err := l.CreateInstance(ctx, hookBootstrap())
+	require.NoError(t, err)
+	require.Equal(t, "mutated-by-hook", got.Description)
+}
+
+func TestCreateInstanceHookFailureCleansUp(t *testing.T) {
+	ctx := context.Background()
+	cli := new(MockIncusServer)
+	l := newHookProvider(cli, config.Hooks{
+		VMPostCreate: &config.Hook{Command: writeExecScript(t, "exit 1")},
+	})
+	op := setupCreateFlow(cli)
+	cli.On("CreateInstance", mock.Anything).Return(op, nil)
+	cli.On("UpdateInstanceState", "test-instance", mock.Anything, "").Return(op, nil)
+	cli.On("DeleteInstance", "test-instance").Return(op, nil)
+
+	_, err := l.CreateInstance(ctx, hookBootstrap())
+	require.Error(t, err)
+	cli.AssertCalled(t, "DeleteInstance", "test-instance")
+}
+
+func TestCreateInstanceHookIgnoreFailure(t *testing.T) {
+	ctx := context.Background()
+	cli := new(MockIncusServer)
+	l := newHookProvider(cli, config.Hooks{
+		VMPostCreate: &config.Hook{Command: writeExecScript(t, "exit 1"), IgnoreFailure: true},
+	})
+	op := setupCreateFlow(cli)
+	cli.On("CreateInstance", mock.Anything).Return(op, nil)
+	cli.On("UpdateInstanceState", "test-instance", mock.Anything, "").Return(op, nil)
+	mockInstanceWithIP(cli)
+
+	_, err := l.CreateInstance(ctx, hookBootstrap())
+	require.NoError(t, err)
+	cli.AssertNotCalled(t, "DeleteInstance", "test-instance")
+}
+
+func TestDeleteInstanceRunsDeleteHooks(t *testing.T) {
+	ctx := context.Background()
+	cli := new(MockIncusServer)
+	marker := filepath.Join(t.TempDir(), "del")
+	l := newHookProvider(cli, config.Hooks{
+		VMPreDelete:  markerHook(t, marker),
+		VMPostDelete: markerHook(t, marker),
+	})
+	op := new(MockOperation)
+	op.On("WaitContext", mock.Anything).Return(nil)
+	mockInstanceWithIP(cli)
+	cli.On("UpdateInstanceState", "test-instance", mock.Anything, "").Return(op, nil)
+	cli.On("DeleteInstance", "test-instance").Return(op, nil)
+
+	require.NoError(t, l.DeleteInstance(ctx, "test-instance"))
+	got, err := os.ReadFile(marker)
+	require.NoError(t, err)
+	require.Equal(t, "vm_pre_delete vm_post_delete ", string(got))
+}
+
+func TestDeleteInstanceDeleteHookFailureNonBlocking(t *testing.T) {
+	ctx := context.Background()
+	cli := new(MockIncusServer)
+	l := newHookProvider(cli, config.Hooks{
+		VMPreDelete: &config.Hook{Command: writeExecScript(t, "exit 1")},
+	})
+	op := new(MockOperation)
+	op.On("WaitContext", mock.Anything).Return(nil)
+	mockInstanceWithIP(cli)
+	cli.On("UpdateInstanceState", "test-instance", mock.Anything, "").Return(op, nil)
+	cli.On("DeleteInstance", "test-instance").Return(op, nil)
+
+	require.NoError(t, l.DeleteInstance(ctx, "test-instance"))
+	cli.AssertCalled(t, "DeleteInstance", "test-instance")
+}
+
+func TestDeleteInstanceNoHooksRawPath(t *testing.T) {
+	ctx := context.Background()
+	cli := new(MockIncusServer)
+	l := newHookProvider(cli, config.Hooks{})
+	op := new(MockOperation)
+	op.On("WaitContext", mock.Anything).Return(nil)
+	cli.On("UpdateInstanceState", "test-instance", mock.Anything, "").Return(op, nil)
+	cli.On("DeleteInstance", "test-instance").Return(op, nil)
+
+	require.NoError(t, l.DeleteInstance(ctx, "test-instance"))
+	cli.AssertNotCalled(t, "GetInstanceFull", "test-instance")
+	cli.AssertCalled(t, "DeleteInstance", "test-instance")
+}
+
+func TestRemoveAllInstancesRunsDeleteHooks(t *testing.T) {
+	ctx := context.Background()
+	cli := new(MockIncusServer)
+	marker := filepath.Join(t.TempDir(), "del")
+	l := newHookProvider(cli, config.Hooks{VMPreDelete: markerHook(t, marker)})
+	cli.On("GetInstancesFull", api.InstanceTypeAny).Return([]api.InstanceFull{
+		{
+			Instance: api.Instance{
+				InstancePut:    api.InstancePut{Architecture: "x86_64"},
+				Name:           "test-instance",
+				ExpandedConfig: map[string]string{"image.os": "ubuntu", poolIDKey: "default", controllerIDKeyName: "controller"},
+				Type:           "virtual-machine",
+			},
+			State: &api.InstanceState{Status: "Running"},
+		},
+	}, nil)
+	op := new(MockOperation)
+	op.On("WaitContext", mock.Anything).Return(nil)
+	mockInstanceWithIP(cli)
+	cli.On("UpdateInstanceState", "test-instance", mock.Anything, "").Return(op, nil)
+	cli.On("DeleteInstance", "test-instance").Return(op, nil)
+
+	require.NoError(t, l.RemoveAllInstances(ctx))
+	got, err := os.ReadFile(marker)
+	require.NoError(t, err)
+	require.Equal(t, "vm_pre_delete ", string(got))
 }

--- a/provider/incus_test.go
+++ b/provider/incus_test.go
@@ -17,6 +17,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -839,10 +840,10 @@ func mockInstanceWithIP(cli *MockIncusServer) {
 	}, "", nil)
 }
 
-// markerHook returns a hook whose script appends $GARM_HOOK to the marker file
-// (passed as arg $1) and writes nothing to stdout.
-func markerHook(t *testing.T, marker string) *config.Hook {
-	return &config.Hook{Command: writeExecScript(t, `printf '%s ' "$GARM_HOOK" >> "$1"`), Args: []string{marker}}
+// markerHook returns a hook that appends $GARM_HOOK to the marker file and
+// writes nothing to stdout.
+func markerHook(marker string) *config.Hook {
+	return &config.Hook{Command: fmt.Sprintf(`printf '%%s ' "$GARM_HOOK" >> %q`, marker)}
 }
 
 func TestCreateInstanceRunsHooksInOrder(t *testing.T) {
@@ -850,10 +851,10 @@ func TestCreateInstanceRunsHooksInOrder(t *testing.T) {
 	cli := new(MockIncusServer)
 	marker := filepath.Join(t.TempDir(), "order")
 	l := newHookProvider(cli, config.Hooks{
-		VMPreCreate:  markerHook(t, marker),
-		VMPostCreate: markerHook(t, marker),
-		VMPreStart:   markerHook(t, marker),
-		VMPostStart:  markerHook(t, marker),
+		VMPreCreate:  markerHook(marker),
+		VMPostCreate: markerHook(marker),
+		VMPreStart:   markerHook(marker),
+		VMPostStart:  markerHook(marker),
 	})
 	op := setupCreateFlow(cli)
 	cli.On("CreateInstance", mock.Anything).Return(op, nil)
@@ -871,13 +872,10 @@ func TestCreateInstanceRunsHooksInOrder(t *testing.T) {
 func TestCreateInstancePreCreateMutation(t *testing.T) {
 	ctx := context.Background()
 	cli := new(MockIncusServer)
-	dir := t.TempDir()
-	jsonPath := filepath.Join(dir, "out.json")
+	jsonPath := filepath.Join(t.TempDir(), "out.json")
 	require.NoError(t, os.WriteFile(jsonPath, []byte(`{"name":"test-instance","architecture":"x86_64","description":"mutated-by-hook","type":"virtual-machine","source":{"type":"image","fingerprint":"123abc"},"profiles":["default","virtual-machine"],"config":{"user.runner-pool-id":"default"}}`), 0o644))
-	script := filepath.Join(dir, "hook.sh")
-	require.NoError(t, os.WriteFile(script, []byte("#!/bin/sh\ncat >/dev/null; cat \"$1\"\n"), 0o755))
 
-	l := newHookProvider(cli, config.Hooks{VMPreCreate: &config.Hook{Command: script, Args: []string{jsonPath}}})
+	l := newHookProvider(cli, config.Hooks{VMPreCreate: &config.Hook{Command: fmt.Sprintf("cat >/dev/null; cat %q", jsonPath)}})
 	op := setupCreateFlow(cli)
 	var got api.InstancesPost
 	cli.On("CreateInstance", mock.Anything).Run(func(a mock.Arguments) { got = a.Get(0).(api.InstancesPost) }).Return(op, nil)
@@ -889,11 +887,25 @@ func TestCreateInstancePreCreateMutation(t *testing.T) {
 	require.Equal(t, "mutated-by-hook", got.Description)
 }
 
+func TestCreateInstancePreCreateNameChangeRejected(t *testing.T) {
+	ctx := context.Background()
+	cli := new(MockIncusServer)
+	jsonPath := filepath.Join(t.TempDir(), "out.json")
+	require.NoError(t, os.WriteFile(jsonPath, []byte(`{"name":"renamed","architecture":"x86_64","type":"virtual-machine","source":{"type":"image","fingerprint":"123abc"},"profiles":["default","virtual-machine"]}`), 0o644))
+	l := newHookProvider(cli, config.Hooks{VMPreCreate: &config.Hook{Command: fmt.Sprintf("cat >/dev/null; cat %q", jsonPath)}})
+	setupCreateFlow(cli)
+
+	_, err := l.CreateInstance(ctx, hookBootstrap())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must not change the instance name")
+	cli.AssertNotCalled(t, "CreateInstance", mock.Anything)
+}
+
 func TestCreateInstanceHookFailureCleansUp(t *testing.T) {
 	ctx := context.Background()
 	cli := new(MockIncusServer)
 	l := newHookProvider(cli, config.Hooks{
-		VMPostCreate: &config.Hook{Command: writeExecScript(t, "exit 1")},
+		VMPostCreate: &config.Hook{Command: "exit 1"},
 	})
 	op := setupCreateFlow(cli)
 	cli.On("CreateInstance", mock.Anything).Return(op, nil)
@@ -909,7 +921,7 @@ func TestCreateInstanceHookIgnoreFailure(t *testing.T) {
 	ctx := context.Background()
 	cli := new(MockIncusServer)
 	l := newHookProvider(cli, config.Hooks{
-		VMPostCreate: &config.Hook{Command: writeExecScript(t, "exit 1"), IgnoreFailure: true},
+		VMPostCreate: &config.Hook{Command: "exit 1", IgnoreFailure: true},
 	})
 	op := setupCreateFlow(cli)
 	cli.On("CreateInstance", mock.Anything).Return(op, nil)
@@ -926,8 +938,8 @@ func TestDeleteInstanceRunsDeleteHooks(t *testing.T) {
 	cli := new(MockIncusServer)
 	marker := filepath.Join(t.TempDir(), "del")
 	l := newHookProvider(cli, config.Hooks{
-		VMPreDelete:  markerHook(t, marker),
-		VMPostDelete: markerHook(t, marker),
+		VMPreDelete:  markerHook(marker),
+		VMPostDelete: markerHook(marker),
 	})
 	op := new(MockOperation)
 	op.On("WaitContext", mock.Anything).Return(nil)
@@ -945,7 +957,7 @@ func TestDeleteInstanceDeleteHookFailureNonBlocking(t *testing.T) {
 	ctx := context.Background()
 	cli := new(MockIncusServer)
 	l := newHookProvider(cli, config.Hooks{
-		VMPreDelete: &config.Hook{Command: writeExecScript(t, "exit 1")},
+		VMPreDelete: &config.Hook{Command: "exit 1"},
 	})
 	op := new(MockOperation)
 	op.On("WaitContext", mock.Anything).Return(nil)
@@ -975,7 +987,7 @@ func TestRemoveAllInstancesRunsDeleteHooks(t *testing.T) {
 	ctx := context.Background()
 	cli := new(MockIncusServer)
 	marker := filepath.Join(t.TempDir(), "del")
-	l := newHookProvider(cli, config.Hooks{VMPreDelete: markerHook(t, marker)})
+	l := newHookProvider(cli, config.Hooks{VMPreDelete: markerHook(marker)})
 	cli.On("GetInstancesFull", api.InstanceTypeAny).Return([]api.InstanceFull{
 		{
 			Instance: api.Instance{

--- a/provider/incus_test.go
+++ b/provider/incus_test.go
@@ -381,7 +381,7 @@ func TestLaunchInstance(t *testing.T) {
 		Timeout: -1,
 	}, "").Return(mockOp, nil)
 
-	err := l.launchInstance(ctx, createArgs, hookContext{})
+	err := l.launchInstance(ctx, createArgs, hookContext{}, config.Hooks{})
 	require.NoError(t, err)
 }
 
@@ -582,6 +582,7 @@ func TestDeleteInstance(t *testing.T) {
 	}
 	mockOp := new(MockOperation)
 	mockOp.On("WaitContext", mock.Anything).Return(nil)
+	cli.On("GetInstanceFull", "test-instance").Return(&api.InstanceFull{}, "", nil)
 	cli.On("DeleteInstance", "test-instance").Return(mockOp, nil)
 	cli.On("UpdateInstanceState", "test-instance", api.InstanceStatePut{
 		Action:  "stop",
@@ -723,6 +724,7 @@ func TestRemoveAllInstances(t *testing.T) {
 	}, nil)
 	mockOp := new(MockOperation)
 	mockOp.On("WaitContext", mock.Anything).Return(nil)
+	cli.On("GetInstanceFull", instanceName).Return(&api.InstanceFull{}, "", nil)
 	cli.On("DeleteInstance", instanceName).Return(mockOp, nil)
 	cli.On("UpdateInstanceState", "test-instance", api.InstanceStatePut{
 		Action:  "stop",
@@ -969,17 +971,17 @@ func TestDeleteInstanceDeleteHookFailureNonBlocking(t *testing.T) {
 	cli.AssertCalled(t, "DeleteInstance", "test-instance")
 }
 
-func TestDeleteInstanceNoHooksRawPath(t *testing.T) {
+func TestDeleteInstanceNoHooks(t *testing.T) {
 	ctx := context.Background()
 	cli := new(MockIncusServer)
 	l := newHookProvider(cli, config.Hooks{})
 	op := new(MockOperation)
 	op.On("WaitContext", mock.Anything).Return(nil)
+	cli.On("GetInstanceFull", "test-instance").Return(&api.InstanceFull{}, "", nil)
 	cli.On("UpdateInstanceState", "test-instance", mock.Anything, "").Return(op, nil)
 	cli.On("DeleteInstance", "test-instance").Return(op, nil)
 
 	require.NoError(t, l.DeleteInstance(ctx, "test-instance"))
-	cli.AssertNotCalled(t, "GetInstanceFull", "test-instance")
 	cli.AssertCalled(t, "DeleteInstance", "test-instance")
 }
 
@@ -1006,6 +1008,163 @@ func TestRemoveAllInstancesRunsDeleteHooks(t *testing.T) {
 	cli.On("DeleteInstance", "test-instance").Return(op, nil)
 
 	require.NoError(t, l.RemoveAllInstances(ctx))
+	got, err := os.ReadFile(marker)
+	require.NoError(t, err)
+	require.Equal(t, "vm_pre_delete ", string(got))
+}
+
+func hookBootstrapWithSpecs(specs string) commonParams.BootstrapInstance {
+	bp := hookBootstrap()
+	bp.ExtraSpecs = []byte(specs)
+	return bp
+}
+
+func TestCreateInstanceExtraSpecsOverridesConfigHooks(t *testing.T) {
+	ctx := context.Background()
+	cli := new(MockIncusServer)
+	dir := t.TempDir()
+	cfgMarker := filepath.Join(dir, "cfg")
+	esMarker := filepath.Join(dir, "es")
+	l := newHookProvider(cli, config.Hooks{
+		VMPreCreate: &config.Hook{Command: fmt.Sprintf("printf config > %q", cfgMarker)},
+	})
+	op := setupCreateFlow(cli)
+	cli.On("CreateInstance", mock.Anything).Return(op, nil)
+	cli.On("UpdateInstanceState", "test-instance", mock.Anything, "").Return(op, nil)
+	mockInstanceWithIP(cli)
+
+	specs := fmt.Sprintf(`{"hooks":{"vm_pre_create":{"command":%q}}}`, fmt.Sprintf("printf extra > %q", esMarker))
+	_, err := l.CreateInstance(ctx, hookBootstrapWithSpecs(specs))
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(esMarker)
+	require.NoError(t, err)
+	require.Equal(t, "extra", string(got))
+	require.NoFileExists(t, cfgMarker)
+}
+
+func TestCreateInstanceExtraSpecsEmptyDisablesConfigHooks(t *testing.T) {
+	ctx := context.Background()
+	cli := new(MockIncusServer)
+	cfgMarker := filepath.Join(t.TempDir(), "cfg")
+	l := newHookProvider(cli, config.Hooks{
+		VMPreCreate: &config.Hook{Command: fmt.Sprintf("printf config > %q", cfgMarker)},
+	})
+	op := setupCreateFlow(cli)
+	cli.On("CreateInstance", mock.Anything).Return(op, nil)
+	cli.On("UpdateInstanceState", "test-instance", mock.Anything, "").Return(op, nil)
+	mockInstanceWithIP(cli)
+
+	_, err := l.CreateInstance(ctx, hookBootstrapWithSpecs(`{"hooks":{}}`))
+	require.NoError(t, err)
+	require.NoFileExists(t, cfgMarker)
+}
+
+func TestCreateInstancePersistsDeleteHooks(t *testing.T) {
+	ctx := context.Background()
+	cli := new(MockIncusServer)
+	l := newHookProvider(cli, config.Hooks{})
+	op := setupCreateFlow(cli)
+	var got api.InstancesPost
+	cli.On("CreateInstance", mock.Anything).Run(func(a mock.Arguments) { got = a.Get(0).(api.InstancesPost) }).Return(op, nil)
+	cli.On("UpdateInstanceState", "test-instance", mock.Anything, "").Return(op, nil)
+	mockInstanceWithIP(cli)
+
+	_, err := l.CreateInstance(ctx, hookBootstrapWithSpecs(`{"hooks":{"vm_pre_delete":{"command":"true"}}}`))
+	require.NoError(t, err)
+	require.Contains(t, got.Config[deleteHooksKeyName], `"vm_pre_delete"`)
+	require.Contains(t, got.Config[deleteHooksKeyName], `"command":"true"`)
+}
+
+func TestDeleteInstanceUsesPersistedHooks(t *testing.T) {
+	ctx := context.Background()
+	cli := new(MockIncusServer)
+	marker := filepath.Join(t.TempDir(), "del")
+	// config defines a failing delete hook; the persisted one must win.
+	l := newHookProvider(cli, config.Hooks{VMPreDelete: &config.Hook{Command: "exit 1"}})
+	persisted := fmt.Sprintf(`{"vm_pre_delete":{"command":%q}}`, fmt.Sprintf("printf persisted > %q", marker))
+	cli.On("GetInstanceFull", "test-instance").Return(&api.InstanceFull{
+		Instance: api.Instance{
+			Name:           "test-instance",
+			ExpandedConfig: map[string]string{deleteHooksKeyName: persisted},
+		},
+	}, "", nil)
+	op := new(MockOperation)
+	op.On("WaitContext", mock.Anything).Return(nil)
+	cli.On("UpdateInstanceState", "test-instance", mock.Anything, "").Return(op, nil)
+	cli.On("DeleteInstance", "test-instance").Return(op, nil)
+
+	require.NoError(t, l.DeleteInstance(ctx, "test-instance"))
+	got, err := os.ReadFile(marker)
+	require.NoError(t, err)
+	require.Equal(t, "persisted", string(got))
+}
+
+func TestDeleteInstanceCorruptPersistedHooksSkips(t *testing.T) {
+	ctx := context.Background()
+	cli := new(MockIncusServer)
+	marker := filepath.Join(t.TempDir(), "del")
+	// A corrupt persisted value is replace-mode, so config hooks must NOT leak.
+	l := newHookProvider(cli, config.Hooks{VMPreDelete: markerHook(marker)})
+	cli.On("GetInstanceFull", "test-instance").Return(&api.InstanceFull{
+		Instance: api.Instance{
+			Name:           "test-instance",
+			ExpandedConfig: map[string]string{deleteHooksKeyName: "not json{"},
+		},
+	}, "", nil)
+	op := new(MockOperation)
+	op.On("WaitContext", mock.Anything).Return(nil)
+	cli.On("UpdateInstanceState", "test-instance", mock.Anything, "").Return(op, nil)
+	cli.On("DeleteInstance", "test-instance").Return(op, nil)
+
+	require.NoError(t, l.DeleteInstance(ctx, "test-instance"))
+	require.NoFileExists(t, marker)
+}
+
+func TestDeleteInstanceNotFoundRunsNoHooks(t *testing.T) {
+	ctx := context.Background()
+	cli := new(MockIncusServer)
+	marker := filepath.Join(t.TempDir(), "del")
+	l := newHookProvider(cli, config.Hooks{VMPreDelete: markerHook(marker)})
+	cli.On("GetInstanceFull", "test-instance").Return((*api.InstanceFull)(nil), "", os.ErrNotExist)
+	op := new(MockOperation)
+	op.On("WaitContext", mock.Anything).Return(nil)
+	cli.On("UpdateInstanceState", "test-instance", mock.Anything, "").Return(op, nil)
+	cli.On("DeleteInstance", "test-instance").Return(op, nil)
+
+	require.NoError(t, l.DeleteInstance(ctx, "test-instance"))
+	require.NoFileExists(t, marker)
+}
+
+func TestDeleteInstanceClientErrorUsesConfigHooks(t *testing.T) {
+	ctx := context.Background()
+	marker := filepath.Join(t.TempDir(), "del")
+	// cli is nil and the config has no endpoint, so getCLI fails; config hooks
+	// must still run best-effort (the raw delete then errors).
+	l := &Incus{
+		cfg:          &config.Incus{Hooks: config.Hooks{VMPreDelete: markerHook(marker)}},
+		imageManager: &image{},
+		controllerID: "controller",
+	}
+	require.Error(t, l.DeleteInstance(ctx, "test-instance"))
+	got, err := os.ReadFile(marker)
+	require.NoError(t, err)
+	require.Equal(t, "vm_pre_delete ", string(got))
+}
+
+func TestDeleteInstanceReadErrorUsesConfigHooks(t *testing.T) {
+	ctx := context.Background()
+	cli := new(MockIncusServer)
+	marker := filepath.Join(t.TempDir(), "del")
+	l := newHookProvider(cli, config.Hooks{VMPreDelete: markerHook(marker)})
+	// A non-not-found read error must not silently skip the delete hooks.
+	cli.On("GetInstanceFull", "test-instance").Return((*api.InstanceFull)(nil), "", fmt.Errorf("boom"))
+	op := new(MockOperation)
+	op.On("WaitContext", mock.Anything).Return(nil)
+	cli.On("UpdateInstanceState", "test-instance", mock.Anything, "").Return(op, nil)
+	cli.On("DeleteInstance", "test-instance").Return(op, nil)
+
+	require.NoError(t, l.DeleteInstance(ctx, "test-instance"))
 	got, err := os.ReadFile(marker)
 	require.NoError(t, err)
 	require.Equal(t, "vm_pre_delete ", string(got))

--- a/provider/specs.go
+++ b/provider/specs.go
@@ -21,14 +21,16 @@ import (
 
 	"github.com/cloudbase/garm-provider-common/cloudconfig"
 	commonParams "github.com/cloudbase/garm-provider-common/params"
+	"github.com/cloudbase/garm-provider-incus/config"
 	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 )
 
 type extraSpecs struct {
-	ExtraPackages   []string `json:"extra_packages,omitempty" jsonschema:"description=A list of packages that cloud-init should install on the instance."`
-	DisableUpdates  bool     `json:"disable_updates,omitempty" jsonschema:"description=Whether to disable updates when cloud-init comes online."`
-	EnableBootDebug bool     `json:"enable_boot_debug,omitempty" jsonschema:"description=Allows providers to set the -x flag in the runner install script."`
+	ExtraPackages   []string      `json:"extra_packages,omitempty" jsonschema:"description=A list of packages that cloud-init should install on the instance."`
+	DisableUpdates  bool          `json:"disable_updates,omitempty" jsonschema:"description=Whether to disable updates when cloud-init comes online."`
+	EnableBootDebug bool          `json:"enable_boot_debug,omitempty" jsonschema:"description=Allows providers to set the -x flag in the runner install script."`
+	Hooks           *config.Hooks `json:"hooks,omitempty" jsonschema:"description=Lifecycle hooks for this pool. When set, it fully replaces the provider config hooks."`
 	cloudconfig.CloudConfigSpec
 }
 
@@ -58,6 +60,9 @@ func parseExtraSpecsFromBootstrapParams(bootstrapParams commonParams.BootstrapIn
 
 	if err := json.Unmarshal(bootstrapParams.ExtraSpecs, &specs); err != nil {
 		return specs, errors.Wrap(err, "unmarshaling extra specs")
+	}
+	if err := specs.Hooks.Validate(); err != nil {
+		return specs, errors.Wrap(err, "validating hooks")
 	}
 	return specs, nil
 }

--- a/provider/specs_test.go
+++ b/provider/specs_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cloudbase/garm-provider-common/cloudconfig"
 	"github.com/cloudbase/garm-provider-common/params"
+	"github.com/cloudbase/garm-provider-incus/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -157,6 +158,36 @@ var testCases = []struct {
 		input:          json.RawMessage(`{"additional_property": true}`),
 		expectedOutput: extraSpecs{},
 		errString:      "Additional property additional_property is not allowed",
+	},
+	{
+		name:           "specs just with hooks",
+		input:          json.RawMessage(`{"hooks": {"vm_pre_create": {"command": "/opt/x.sh", "timeout": 30}}}`),
+		expectedOutput: extraSpecs{Hooks: &config.Hooks{VMPreCreate: &config.Hook{Command: "/opt/x.sh", Timeout: 30}}},
+		errString:      "",
+	},
+	{
+		name:           "empty hooks disables config",
+		input:          json.RawMessage(`{"hooks": {}}`),
+		expectedOutput: extraSpecs{Hooks: &config.Hooks{}},
+		errString:      "",
+	},
+	{
+		name:           "hook missing command",
+		input:          json.RawMessage(`{"hooks": {"vm_pre_create": {"timeout": 30}}}`),
+		expectedOutput: extraSpecs{},
+		errString:      "command is required",
+	},
+	{
+		name:           "hook with unknown property",
+		input:          json.RawMessage(`{"hooks": {"vm_pre_create": {"command": "/x", "bogus": 1}}}`),
+		expectedOutput: extraSpecs{},
+		errString:      "Additional property bogus is not allowed",
+	},
+	{
+		name:           "hook with empty command fails validation",
+		input:          json.RawMessage(`{"hooks": {"vm_pre_create": {"command": ""}}}`),
+		expectedOutput: extraSpecs{Hooks: &config.Hooks{VMPreCreate: &config.Hook{Command: ""}}},
+		errString:      "validating hooks",
 	},
 }
 

--- a/testdata/garm-provider-incus.toml
+++ b/testdata/garm-provider-incus.toml
@@ -48,3 +48,25 @@ tls_server_certificate = ""
     public = true
     protocol = "simplestreams"
     skip_verify = false
+# Optional lifecycle hooks. Each block runs an external executable at that
+# lifecycle point. See the "Lifecycle hooks" section of the README for the
+# stdin/stdout contract, environment variables and failure semantics.
+#   command        : path to an executable (run directly, not via a shell)
+#   args           : arguments passed verbatim
+#   timeout        : max seconds (default and cap: 60)
+#   ignore_failure : true = log and continue; false = abort (default)
+# [hooks.vm_pre_create]
+#     command = "/opt/garm/hooks/vm-pre-create.sh"
+#     args = ["--role", "builder"]
+#     timeout = 60
+#     ignore_failure = false
+# [hooks.vm_post_create]
+#     command = "/opt/garm/hooks/vm-post-create.sh"
+# [hooks.vm_pre_start]
+#     command = "/opt/garm/hooks/vm-pre-start.sh"
+# [hooks.vm_post_start]
+#     command = "/opt/garm/hooks/vm-post-start.sh"
+# [hooks.vm_pre_delete]
+#     command = "/opt/garm/hooks/vm-pre-delete.sh"
+# [hooks.vm_post_delete]
+#     command = "/opt/garm/hooks/vm-post-delete.sh"

--- a/testdata/garm-provider-incus.toml
+++ b/testdata/garm-provider-incus.toml
@@ -48,16 +48,14 @@ tls_server_certificate = ""
     public = true
     protocol = "simplestreams"
     skip_verify = false
-# Optional lifecycle hooks. Each block runs an external executable at that
-# lifecycle point. See the "Lifecycle hooks" section of the README for the
-# stdin/stdout contract, environment variables and failure semantics.
-#   command        : path to an executable (run directly, not via a shell)
-#   args           : arguments passed verbatim
+# Optional lifecycle hooks. Each block runs a command at that lifecycle point.
+# See the "Lifecycle hooks" section of the README for the stdin/stdout contract,
+# environment variables and failure semantics.
+#   command        : a shell command line run via /bin/sh -c
 #   timeout        : max seconds (default and cap: 60)
 #   ignore_failure : true = log and continue; false = abort (default)
 # [hooks.vm_pre_create]
-#     command = "/opt/garm/hooks/vm-pre-create.sh"
-#     args = ["--role", "builder"]
+#     command = "/opt/garm/hooks/vm-pre-create.sh --role builder"
 #     timeout = 60
 #     ignore_failure = false
 # [hooks.vm_post_create]


### PR DESCRIPTION
## Problem

The provider drives an instance through create → start → delete, but there's no
way to hook into those steps. If you want to prep a disk before an instance
boots, attach a device to a specific instance, or snapshot/clean up on delete,
today the only option is to fork the provider.

## What this does

Adds six optional lifecycle hooks, each running a command at one point:

| Hook | When |
| --- | --- |
| `vm_pre_create`  | before the instance is created |
| `vm_post_create` | after create, before start (instance stopped) |
| `vm_pre_start`   | before start |
| `vm_post_start`  | after the instance has an IPv4 (incus-agent reachable) |
| `vm_pre_delete`  | before the instance is stopped/removed |
| `vm_post_delete` | after the instance is removed |

`vm_pre_create` gets the incus `InstancesPost` JSON on stdin and can return a
modified one on stdout (e.g. to add a disk device); the others get an
instance-context JSON. Every hook also gets the instance details as `GARM_*`
env vars. Commands run via `/bin/sh -c` and inherit the provider's environment.

Hooks can be set globally in the provider config, or per pool via `extra_specs`,
which replaces the config hooks for that pool (absent → config, `{}` → none).

A few notes: a failing create/start hook tears the instance back down so a
half-built one isn't left behind, while delete hooks only log and never block
deletion, so they must be idempotent. A `vm_pre_create` hook can't rename the
instance — garm tracks it by name — and that's enforced. `ignore_failure` makes
a create/start hook advisory.

---

Implemented by Claude Opus 4.8 — code reviewed by me.