### PR TITLE
Allow running without image remotes

### DIFF
--- a/provider/incus.go
+++ b/provider/incus.go
@@ -92,10 +92,6 @@ func NewIncusProvider(configFile, controllerID string) (execution.ExternalProvid
 		return nil, errors.Wrap(err, "validating provider config")
 	}
 
-	if len(cfg.ImageRemotes) == 0 {
-		return nil, fmt.Errorf("no image remotes configured")
-	}
-
 	provider := &Incus{
 		cfg:          cfg,
 		controllerID: controllerID,


### PR DESCRIPTION
The README states that image remotes are optional and that images are resolved as local aliases on the Incus server if no remote is configured, but the provider refused to start with an empty image_remotes map. Image resolution already handles both cases: images without a remote prefix are looked up as local aliases, and referencing an unconfigured remote returns a clear error.